### PR TITLE
Replace dashes with underscores in product and dependency names so the can be evaluated by bash

### DIFF
--- a/lib/spack/spack/modules/ups_table.py
+++ b/lib/spack/spack/modules/ups_table.py
@@ -67,13 +67,17 @@ class UpsTableFileLayout(BaseFileLayout):
     extension = "table"
 
     def dirname(self):
-        return root_path('ups_table', 'ups') + '/'+ self.spec.format("{name}")
+        return root_path('ups_table', 'ups') 
 
     @property
     def filename(self):
         """Name of the module file for the current spec."""
+        filename = os.path.basename(self.use_name)
+        subdirname = self.spec.format("{name}").replace('-','_')
+        if not os.access(os.path.join(self.dirname(), subdirname),os.F_OK):
+            os.makedirs(os.path.join(self.dirname(), subdirname))
         fn = "{}-{}-{}.table".format(self.spec.name, self.spec.version, self.spec._hash)
-        fp = os.path.join(self.dirname(), fn)
+        fp = os.path.join(self.dirname(), subdirname, fn.replace('-','_'))
         return  fp
 
 class UpsTableContext(BaseContext):

--- a/lib/spack/spack/modules/ups_version.py
+++ b/lib/spack/spack/modules/ups_version.py
@@ -69,7 +69,7 @@ class UpsVersionFileLayout(BaseFileLayout):
     """File layout for ups_version module files."""
 
     def dirname(self):
-        return root_path('ups_version','ups') 
+        return root_path('ups_version','ups')
 
 
     @property
@@ -77,7 +77,7 @@ class UpsVersionFileLayout(BaseFileLayout):
         """Name of the module file for the current spec."""
         # Just the name of the file
         filename = os.path.basename(self.use_name)
-        subdirname = self.spec.format("{name}/{version}.version")
+        subdirname = self.spec.format("{name}/{version}.version").replace('-','_')
         if not os.access(os.path.join(self.dirname(), subdirname),os.F_OK):
             os.makedirs(os.path.join(self.dirname(), subdirname))
         return os.path.join(self.dirname(), subdirname, filename)

--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -1,5 +1,5 @@
 FILE = Table
-PRODUCT = {{spec.name}}
+PRODUCT = {{spec.name|replace("-", "_")}}
 
 FLAVOR=ANY
 
@@ -25,7 +25,7 @@ Action = setup
     prodDir()
     setupEnv()
 {% for package in spec._dependencies.keys() %}
-    setupRequired({{package}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@')[0] == package%}{{c.split('@')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
+    setupRequired({{package|replace("-","_")}} {%for c in (spec|string|replace('\n',' ')).split('^')%}{%if c.split('@')[0] == package%}{{c.split('@')[1].split('%')[0]}}{%endif%}{%endfor%} -f ${UPS_PROD_FLAVOR} -q "${UPS_PROD_QUALIFIERS}")
 {% endfor %}
 
 {% block environment %}

--- a/share/spack/templates/modules/modulefile.ups_table
+++ b/share/spack/templates/modules/modulefile.ups_table
@@ -3,7 +3,9 @@ PRODUCT = {{spec.name|replace("-", "_")}}
 
 FLAVOR=ANY
 
-{% if   (spec.compiler|string).find('gcc@7.3.0')==0   %}{%set upscompquals = 'e17' %}
+{% if   (spec.compiler|string).find('gcc@9.3.0')==0   %}{%set upscompquals = 'e20' %}
+{% elif (spec.compiler|string).find('gcc@8.2.0')==0   %}{%set upscompquals = 'e19' %}
+{% elif (spec.compiler|string).find('gcc@7.3.0')==0   %}{%set upscompquals = 'e17' %}
 {% elif (spec.compiler|string).find('gcc@6.4.0')==0   %}{%set upscompquals = 'e15' %}
 {% elif (spec.compiler|string).find('gcc@6.3.0')==0   %}{%set upscompquals = 'e14' %}
 {% elif (spec.compiler|string).find('gcc@4.9.3')==0   %}{%set upscompquals = 'e10' %}

--- a/share/spack/templates/modules/modulefile.ups_version
+++ b/share/spack/templates/modules/modulefile.ups_version
@@ -52,4 +52,4 @@ QUALIFIERS=""
   MODIFIER = {{username}}
   MODIFIED = {{timestamp}}
   PROD_DIR = {{spec.prefix}}
-  TABLE_FILE = {{spec.name}}-{{spec.version}}-{{spec._hash}}.table
+  TABLE_FILE = {{spec.name|replace("-","_")}}_{{spec.version}}_{{spec._hash}}.table

--- a/share/spack/templates/modules/modulefile.ups_version
+++ b/share/spack/templates/modules/modulefile.ups_version
@@ -1,5 +1,5 @@
 FILE = version
-PRODUCT = {{spec.name}}
+PRODUCT = {{spec.name|replace("-","_")}}
 VERSION = {{spec.version}}
 
 {% if   (spec.architecture|string).find('i686')>0   %}{%set upsbits = '' %}

--- a/share/spack/templates/modules/modulefile.ups_version
+++ b/share/spack/templates/modules/modulefile.ups_version
@@ -28,7 +28,9 @@ VERSION = {{spec.version}}
 {% endif %}
 
 
-{% if   (spec.compiler|string).find('gcc@7.3.0')==0   %}{%set upscompquals = 'e17' %}
+{% if   (spec.compiler|string).find('gcc@9.3.0')==0   %}{%set upscompquals = 'e20' %}
+{% elif (spec.compiler|string).find('gcc@8.2.0')==0   %}{%set upscompquals = 'e19' %}
+{% elif (spec.compiler|string).find('gcc@7.3.0')==0   %}{%set upscompquals = 'e17' %}
 {% elif (spec.compiler|string).find('gcc@6.4.0')==0   %}{%set upscompquals = 'e15' %}
 {% elif (spec.compiler|string).find('gcc@6.3.0')==0   %}{%set upscompquals = 'e14' %}
 {% elif (spec.compiler|string).find('gcc@4.9.3')==0   %}{%set upscompquals = 'e10' %}


### PR DESCRIPTION
This change requires making an alternate directory with the spack package name that has dashes replaced with underscores. The table and version files written in that directory will refer the spack installation directory.
For example, the spack package libjpeg-turbo will have ups table and version files written to libjpeg_turbo.